### PR TITLE
refactor: export ActorHandler, use cf-workers lib without ambient env

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@rivetkit/actor": "0.9.8",
-    "@rivetkit/cloudflare-workers": "0.9.8",
+    "@rivetkit/cloudflare-workers": "https://pkg.pr.new/rivet-gg/rivetkit/@rivetkit/cloudflare-workers@1157",
     "react": "19.1.1",
     "react-dom": "19.1.1"
   },

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -9,41 +9,44 @@ export type AgentNameParts = [OrgId, UserId];
 export type AgentName = Join<AgentNameParts, ":">;
 
 export const makeUserActor = async (nameParts: AgentNameParts) => {
-  return client.user.getOrCreate(nameParts.join(":"));
+	return client.user.getOrCreate(nameParts.join(":"));
 };
 
 export const user = actor({
-  state: { count: 0 },
-  actions: {
-    getCount: (c) => c.state.count,
-    increment: (c, amount: number = 1) => {
-      console.log("actorName", c.name);
-      c.state.count += amount;
-      c.broadcast("countChanged", c.state.count);
-      return c.state.count;
-    },
-  },
+	state: { count: 0 },
+	actions: {
+		getCount: (c) => c.state.count,
+		increment: (c, amount: number = 1) => {
+			console.log("actorName", c.name);
+			c.state.count += amount;
+			c.broadcast("countChanged", c.state.count);
+			return c.state.count;
+		},
+	},
 });
 
 const registry = setup({
-  use: { user },
+	use: { user },
 });
 
-const { client } = createServer(registry);
+const { client, createHandler } = createServer(registry);
+
+const { handler, ActorHandler } = createHandler();
+
+export { ActorHandler };
 
 export default {
-  async fetch(req) {
-    const url = new URL(req.url);
+	...handler,
+	fetch: async (request: Request, env, ctx) => {
+		const url = new URL(request.url);
 
-    if (url.pathname === "/debug/actor") {
-      const user = await makeUserActor(["org_1", "ag_1"]);
+		if (url.pathname === "/debug/actor") {
+			const user = await makeUserActor(["org_1", "ag_1"]);
 
-      await user.increment(1);
-      const newCount = await user.getCount();
-
-      return new Response(`new count ${newCount}`);
-    }
-
-    return new Response("Not found", { status: 404 });
-  },
-} satisfies ExportedHandler<Env>;
+			await user.increment(1);
+			const newCount = await user.getCount();
+			return new Response(`new count ${newCount}`);
+		}
+		return handler.fetch(request, env, ctx);
+	},
+} satisfies ExportedHandler;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -27,8 +27,8 @@
   "durable_objects": {
     "bindings": [
       {
-        "class_name": "AgentDO",
-        "name": "AgentDO"
+        "class_name": "ActorHandler",
+        "name": "ACTOR_DO"
       }
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,15 +1224,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rivetkit/cloudflare-workers@npm:0.9.8":
+"@rivetkit/cloudflare-workers@https://pkg.pr.new/rivet-gg/rivetkit/@rivetkit/cloudflare-workers@1157":
   version: 0.9.8
-  resolution: "@rivetkit/cloudflare-workers@npm:0.9.8"
+  resolution: "@rivetkit/cloudflare-workers@https://pkg.pr.new/rivet-gg/rivetkit/@rivetkit/cloudflare-workers@1157"
   dependencies:
-    "@rivetkit/core": "npm:0.9.8"
+    "@rivetkit/core": "https://pkg.pr.new/rivet-gg/rivetkit/@rivetkit/core@679bbde6fd24dd545975c520b12202af50b2c154"
     hono: "npm:4.8.3"
     invariant: "npm:^2.2.4"
     zod: "npm:^3.25.76"
-  checksum: 10c0/514d6a89da10bd5b147c12f7c045d766100fae7dc0bc426ec3726b24a8d9e3114dcc31d4394418b8aad1b5e2aef910760feacf2e46041544cd6b90d3a547a0aa
+  checksum: 10c0/034fd2c7bedc8f52848fc83b719990d3661ef13f8465e0a8f98ba0f00936cd345ed6eeecad247fd8c78cc4c6c04d66d6a565af82d0a044d2543dc8202667f297
+  languageName: node
+  linkType: hard
+
+"@rivetkit/core@https://pkg.pr.new/rivet-gg/rivetkit/@rivetkit/core@679bbde6fd24dd545975c520b12202af50b2c154":
+  version: 0.9.8
+  resolution: "@rivetkit/core@https://pkg.pr.new/rivet-gg/rivetkit/@rivetkit/core@679bbde6fd24dd545975c520b12202af50b2c154"
+  dependencies:
+    "@hono/standard-validator": "npm:^0.1.3"
+    "@hono/zod-openapi": "npm:^0.19.10"
+    "@rivetkit/fast-json-patch": "npm:^3.1.2"
+    cbor-x: "npm:^1.6.0"
+    hono: "npm:^4.7.0"
+    invariant: "npm:^2.2.4"
+    nanoevents: "npm:^9.1.0"
+    on-change: "npm:^5.0.1"
+    p-retry: "npm:^6.2.1"
+    zod: "npm:^3.25.76"
+  peerDependencies:
+    "@hono/node-server": ^1.14.0
+    "@hono/node-ws": ^1.1.1
+    eventsource: ^3.0.5
+    ws: ^8.0.0
+  peerDependenciesMeta:
+    "@hono/node-server":
+      optional: true
+    "@hono/node-ws":
+      optional: true
+    eventsource:
+      optional: true
+    ws:
+      optional: true
+  checksum: 10c0/d64c4ae93ef4cd1809ba109328e6030edab74afc66c46770e016945d18076ae14e1b13ae2b97c1c66100611c8eeef73df734ece2ccc880965b653b4197f76328
   languageName: node
   linkType: hard
 
@@ -4137,7 +4169,7 @@ __metadata:
     "@cloudflare/vite-plugin": "npm:1.11.2"
     "@eslint/js": "npm:^9.25.0"
     "@rivetkit/actor": "npm:0.9.8"
-    "@rivetkit/cloudflare-workers": "npm:0.9.8"
+    "@rivetkit/cloudflare-workers": "https://pkg.pr.new/rivet-gg/rivetkit/@rivetkit/cloudflare-workers@1157"
     "@types/react": "npm:^19.1.9"
     "@types/react-dom": "npm:^19.1.7"
     "@vitejs/plugin-react": "npm:5.0.0"


### PR DESCRIPTION

This pull request updates the Cloudflare Worker integration to use the new `ActorHandler` durable object and updates the dependency to a custom package version. The changes modernize the worker's handler setup and ensure the correct durable object is bound for actor operations.

**Cloudflare Worker Durable Object Integration:**

* Updated the durable object binding in `wrangler.jsonc` to use the new `ActorHandler` class and renamed the binding to `ACTOR_DO`.
* Updated the dependency for `@rivetkit/cloudflare-workers` in `package.json` to a custom package URL, ensuring the worker uses the latest changes from the RivetKit repository.

**Worker Handler Refactor:**

* Refactored `worker/index.ts` to use the new `createHandler` API, exporting `ActorHandler` and updating the `fetch` handler to delegate to the new handler logic, while preserving the `/debug/actor` route.